### PR TITLE
Default user now has no "administrator" Tag

### DIFF
--- a/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
@@ -14,7 +14,7 @@ namespace EasyNetQ.Management.Client.Model
             {
                 return tagList.Any()
                     ? string.Join(",", tagList)
-                    : allowedTags.First();
+                    : string.Empty;
 
             }
         }


### PR DESCRIPTION
Changed it as you are unable to create a user without management permissions. This is a common case as you want e.g. a user who is just able to listen on one queue.